### PR TITLE
Docker compose file to run pgAdmin and Postgres containers

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -8,7 +8,6 @@ backend/
 ├── .gitignore
 ├── package.json
 ├── tsconfig.json
-├── nodemon.json
 ├── README.md
 ├── src/ │
 ├──── app.ts │
@@ -46,7 +45,75 @@ The backend uses the following configuration files:
 
 - **`tsconfig.json`**: TypeScript configuration file.
 - **`package.json`**: Contains scripts and dependencies for the backend.
-- **`nodemon.json`**: Nodemon configuration file.
+
+### Running Docker Compose
+
+#### Prerequisites
+
+- Ensure Docker, Docker Desktop and Docker Compose are installed on your machine.
+- Verify Docker is running by executing `docker --version` and `docker-compose --version` in your terminal.
+- Make sure to have Docker Desktop opened before running the steps.
+
+#### Steps to Run Docker Compose
+
+1. **Navigate to the Project Directory:**
+   Open your terminal and change the directory to the location of your `compose.yaml` file.
+   ```sh
+   cd backend
+   ```
+2. **Build and Start Containers:**
+   Use the following command to build and start the containers defined in your `compose.yaml` file.
+
+   ```sh
+   docker-compose up -d
+   ```
+
+   - The command will download the images in `compose.yaml` first, and then initiate the containers.
+   - The `-d` flag ensures that containers are run in the background.
+
+3. **Stopping Containers:**
+   To stop the running containers, use the following command.
+   ```sh
+   docker-compose down
+   ```
+
+#### Additional Commands
+
+- **Viewing Logs:**
+  To view the logs of the running containers, use the following command.
+  ```sh
+  docker-compose logs
+  ```
+- **Listing Running Containers:**
+
+  ```sh
+  docker-compose ps
+  ```
+
+#### Accessing pgAdmin via Docker Compose
+
+This assumes that Docker containers are running.
+
+1. **Access pgAdmin:**
+
+   - Open your web browser and navigate to `http://localhost:8080`.
+   - Log in using the default email (`admin@admin.com`) and password (`admin`).
+
+2. **Add a PostgreSQL Server:**
+
+   - Click on "Servers" then "Register" -> "Server" or navigate to "Object" -> "Register" -> "Server".
+   - In the "General" tab, provide a name for your server.
+   - In the "Connection" tab, enter the details for your PostgreSQL server, including hostname (`postgres`), port (`5432`), username(`admin`), and password (`admin`). (**Note**: Provided values are based on current `compose.yaml` file.)
+   - Click "Save" to add the server.
+
+3. **Connect to the Server:**
+   - Once the server is added, you can connect to it by selecting it from the list of servers and clicking "Connect".
+   - You can now manage your databases, run SQL queries, and perform other administrative tasks using pgAdmin.
+
+#### Notes
+
+- Refer to the [Docker Compose documentation](https://docs.docker.com/compose/) for more detailed information and advanced usage.
+- For more detailed instructions and troubleshooting, refer to the official pgAdmin documentation: [pgAdmin Documentation](https://www.pgadmin.org/docs/).
 
 ### API Endpoints
 

--- a/backend/compose.yaml
+++ b/backend/compose.yaml
@@ -1,0 +1,38 @@
+services:
+  postgres:
+    image: postgres:15.0
+    container_name: postgres
+    environment:
+      POSTGRES_USER: admin
+      POSTGRES_PASSWORD: admin
+      POSTGRES_DB: dev-db
+    ports:
+      - "5434:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    restart: unless-stopped
+    networks:
+      - backend
+
+  pgadmin:
+    image: dpage/pgadmin4:latest
+    container_name: pgadmin
+    environment:
+      PGADMIN_DEFAULT_EMAIL: admin@admin.com
+      PGADMIN_DEFAULT_PASSWORD: admin
+    ports:
+      - "8080:80"
+    depends_on:
+      - postgres
+    volumes:
+      - pgadmin_data:/var/lib/pgadmin
+    restart: unless-stopped
+    networks:
+      - backend
+
+volumes:
+  postgres_data:
+  pgadmin_data:
+networks:
+  backend:
+    driver: bridge


### PR DESCRIPTION
Introducing Docker Compose file to run PostgreSQL and pgAdmin containers in Docker. Detailed instructions on how to initialize the containers were provided.

### Docker Compose Support:

* `backend/compose.yaml`: Added Docker Compose configuration for PostgreSQL and pgAdmin services, including environment variables, ports, volumes, and network settings.
#### Postgres Container
* **Image**: The container runs the official Postgres 15.0 image, which is a relational database management system.
* **Environment variables**: It sets up a database named dev-db with a user admin and password admin.
* **Ports**: It maps port 5432 (default Postgres port) inside the container to port 5434 on your local machine.
* **Volumes**: Data is persisted using the volume postgres_data, which maps to the container’s data directory (/var/lib/postgresql/data).
* **Restart policy**: The container will automatically restart unless manually stopped.
* **Network**: It is part of the backend network to communicate with other containers.
#### pgAdmin Container
* **Image**: This container runs pgAdmin 4, a web-based GUI for managing PostgreSQL databases.
* **Environment variables**: Sets the default admin credentials (admin@admin.com as the email, admin as the password).
* **Ports**: Maps the container’s port 80 to port 8080 on your local machine, allowing access to pgAdmin via http://localhost:8080.
* **Depends on**: It waits for the Postgres container to start before running.
* **Volumes**: Stores pgAdmin's data (such as settings) in the volume pgadmin_data.
* **Restart policy**: Also set to automatically restart unless stopped.
* **Network**: Also connected to the backend network, enabling communication with the Postgres container.
#### Volumes and Networks
* **Volumes**: postgres_data and pgadmin_data ensure that the data from Postgres and pgAdmin persist across container restarts.
* **Network (backend)**: Both containers are connected via the backend network (using the bridge driver), allowing them to communicate with each other.

### Documentation Updates:

* `backend/README.md`: Removed the reference to `nodemon.json` and added comprehensive instructions for running Docker Compose, including prerequisites, steps to build and start containers, and accessing pgAdmin.